### PR TITLE
Clean up loadbalancer pool members before delete instance

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -143,7 +143,7 @@ type Instance struct {
 	// +optional
 	DataVolumes []Volume `json:"dataVolumes,omitempty"`
 
-	// Addresses contains the AWS instance associated addresses.
+	// Addresses contains the ECS instance associated addresses.
 	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
 	// Availability zone of instance

--- a/internal/controller/huaweicloudmachine_controller.go
+++ b/internal/controller/huaweicloudmachine_controller.go
@@ -251,6 +251,12 @@ func (r *HuaweiCloudMachineReconciler) reconcileDelete(machineScope *scope.Machi
 
 	machineScope.Logger.Info("ECS instance found matching deleted HuaweiCloudMachine", "instance-id", instance.ID)
 
+	if machineScope.IsControlPlane() {
+		if err := ecsSvc.DetachInstanceFromElb(instance); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Check the instance state. If it's already shutting down or terminated,
 	// do nothing. Otherwise attempt to delete it.
 	switch instance.State {

--- a/pkg/services/ecs/instance.go
+++ b/pkg/services/ecs/instance.go
@@ -183,6 +183,10 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte,
 		return nil, err
 	}
 
+	// Set the providerID and instanceID as soon as we create an instance so that we keep it in case of errors afterward
+	scope.SetProviderID(out.ID, out.AvailabilityZone)
+	scope.SetInstanceID(out.ID)
+
 	return out, nil
 }
 
@@ -406,5 +410,5 @@ func (s *Service) AttachInstanceToElb(instance *infrav1.Instance) error {
 }
 
 func (s *Service) DetachInstanceFromElb(instance *infrav1.Instance) error {
-	return errors.New("DetachInstanceFromElb not implemented")
+	return s.elbService.DeleteMember(s.scope.ELB().Pools, instance)
 }


### PR DESCRIPTION
When deleting an instance, it should delete all loadbalancer pool members attached to it.