### PR TITLE
Fix providerID format

### DIFF
--- a/internal/controller/huaweicloudmachine_controller.go
+++ b/internal/controller/huaweicloudmachine_controller.go
@@ -345,7 +345,7 @@ func (r *HuaweiCloudMachineReconciler) reconcileNormal(_ context.Context, machin
 	}
 
 	// Make sure Spec.ProviderID and Spec.InstanceID are always set.
-	machineScope.SetProviderID(instance.ID, instance.AvailabilityZone)
+	machineScope.SetProviderID(instance.ID)
 	machineScope.SetInstanceID(instance.ID)
 
 	existingInstanceState := machineScope.GetInstanceState()

--- a/pkg/scope/machine.go
+++ b/pkg/scope/machine.go
@@ -122,8 +122,8 @@ func (m *MachineScope) GetProviderID() string {
 }
 
 // SetProviderID sets the HuaweiCloudMachine providerID in spec.
-func (m *MachineScope) SetProviderID(instanceID, availabilityZone string) {
-	providerID := GenerateProviderID(availabilityZone, instanceID)
+func (m *MachineScope) SetProviderID(instanceID string) {
+	providerID := GenerateProviderID(instanceID)
 	m.HCMachine.Spec.ProviderID = ptr.To[string](providerID)
 }
 

--- a/pkg/scope/provider.go
+++ b/pkg/scope/provider.go
@@ -96,5 +96,5 @@ const ProviderIDPrefix = "huaweicloud://"
 //
 // By default, the last id provided is used as identifier (last part).
 func GenerateProviderID(ids ...string) string {
-	return fmt.Sprintf("%s/%s", ProviderIDPrefix, strings.Join(ids, "/"))
+	return fmt.Sprintf("%s%s", ProviderIDPrefix, strings.Join(ids, "/"))
 }

--- a/pkg/services/ecs/instance.go
+++ b/pkg/services/ecs/instance.go
@@ -184,7 +184,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope, userData []byte,
 	}
 
 	// Set the providerID and instanceID as soon as we create an instance so that we keep it in case of errors afterward
-	scope.SetProviderID(out.ID, out.AvailabilityZone)
+	scope.SetProviderID(out.ID)
 	scope.SetInstanceID(out.ID)
 
 	return out, nil
@@ -195,7 +195,6 @@ func (s *Service) runInstance(i *infrav1.Instance) (*infrav1.Instance, error) {
 		XClientToken: ptr.To(string(uuid.NewUUID())),
 		Body: &ecsModel.CreateServersRequestBody{
 			Server: &ecsModel.PrePaidServer{
-				AdminPass: ptr.To("dangerous@2025"),
 				Name:      generateInstanceName("caphw-ecs"),
 				ImageRef:  i.ImageID,
 				FlavorRef: i.Type,


### PR DESCRIPTION
**Type of PR:**
/kind enhancement

**What this PR does / why we need it:**
From the [cloud-provider-huaweicloud code](https://github.com/kubernetes-sigs/cloud-provider-huaweicloud/blob/8e7d341fb54ec8ace3716b4fb0589d9c4603bfb2/pkg/cloudprovider/huaweicloud/instances.go#L256) we know that providerID is actually formated as `huaweicloud://<InstanceID>`

**Which issue(s) this PR fixes:**
<!-- Optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged -->
Fixes #

**Release note:**
<!-- Write your release note. If no release note is required, just write "NONE". -->
```release-note

```
