### PR TITLE
Migrate Cloud Controller to Deployment and Fix CIDR Conflict

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -9,7 +9,7 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-      - 192.168.0.0/16
+      - 10.244.0.0/16
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
@@ -266,7 +266,7 @@ data:
         namespace: kube-system
     ---
     apiVersion: apps/v1
-    kind: DaemonSet
+    kind: Deployment
     metadata:
       name: huawei-cloud-controller-manager
       namespace: kube-system
@@ -281,8 +281,16 @@ data:
           labels:
             k8s-app: huawei-cloud-controller-manager
         spec:
-          nodeSelector:
-            kubernetes.io/os: linux
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: node-role.kubernetes.io/master
+                      operator: Exists
+                  - matchExpressions:
+                    - key: node-role.kubernetes.io/control-plane
+                      operator: Exists
           securityContext:
             runAsUser: 1001
           tolerations:
@@ -296,7 +304,7 @@ data:
           serviceAccountName: cloud-controller-manager
           containers:
             - name: huawei-cloud-controller-manager
-              image: swr.cn-north-4.myhuaweicloud.com/k8s-cloudprovider/huawei-cloud-controller-manager:v0.26.9
+              image: swr.ap-southeast-1.myhuaweicloud.com/huaweiclouddeveloper/huawei-cloud-controller-manager:v0.03
               args:
                 - /bin/huawei-cloud-controller-manager
                 - --v=5


### PR DESCRIPTION
**Type of PR:**
<!-- Add one of the following kinds: feature, bug, api-change, cleanup, deprecation, design, documentation, failing-test, flake, regression, support -->
/kind enhancement
<!--
Add one of the following kinds:
/kind enhancement
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it:**
<!-- Enter a description of the change and why this change is needed -->
- The current DaemonSet deployment of cloud-provider-huaweicloud forces a controller instance to run on every node, leading to resource utilization inefficiencies and redundant processes.
- Pod CIDR assignment in cluster template may overlaps with subnet configurations.

**Which issue(s) this PR fixes:**
<!-- Optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged -->
Fixes #

**Release note:**
<!-- Write your release note. If no release note is required, just write "NONE". -->
```release-note

```
