### PR TITLE
Fix mdbook tabs display and broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ to deploy and manage Kubernetes clusters on Huawei Cloud.
 
 ## Kubernetes versions with published HMIs
 
-See [hmis](docs/book/src/images/hmis.md) for the list of most recently published HMIs.
+See [hmis](https://huaweiclouddeveloper.github.io/cluster-api-provider-huawei/images/hmis.html) for the list of most recently published HMIs.

--- a/docs/book/src/images/index.md
+++ b/docs/book/src/images/index.md
@@ -1,1 +1,4 @@
 # HMIs
+
+Huawei Machine Images for CAPHW Clusters
+CAPHW requires a “machine image” containing pre-installed, matching versions of kubeadm and kubelet. Machine image is required during the cluster creation in the HuaweiCloudMachineTemplate spec.

--- a/docs/book/theme/css/general.css
+++ b/docs/book/theme/css/general.css
@@ -536,8 +536,20 @@ cite.literate-source > a::before {
 .tabset > input:nth-child(9):checked ~ .tab-panels > .tab-panel:nth-child(5),
 .tabset > input:nth-child(11):checked ~ .tab-panels > .tab-panel:nth-child(6),
 .tabset > input:nth-child(13):checked ~ .tab-panels > .tab-panel:nth-child(7),
-.tabset > input:nth-child(15):checked ~ .tab-panels > .tab-panel:nth-child(8){
-  display: block;
+.tabset > input:nth-child(15):checked ~ .tab-panels > .tab-panel:nth-child(8),
+.tabset > input:nth-child(17):checked ~ .tab-panels > .tab-panel:nth-child(9),
+.tabset > input:nth-child(19):checked ~ .tab-panels > .tab-panel:nth-child(10),
+.tabset > input:nth-child(21):checked ~ .tab-panels > .tab-panel:nth-child(11),
+.tabset > input:nth-child(23):checked ~ .tab-panels > .tab-panel:nth-child(12),
+.tabset > input:nth-child(25):checked ~ .tab-panels > .tab-panel:nth-child(13),
+.tabset > input:nth-child(27):checked ~ .tab-panels > .tab-panel:nth-child(14),
+.tabset > input:nth-child(29):checked ~ .tab-panels > .tab-panel:nth-child(15),
+.tabset > input:nth-child(31):checked ~ .tab-panels > .tab-panel:nth-child(16),
+.tabset > input:nth-child(33):checked ~ .tab-panels > .tab-panel:nth-child(17),
+.tabset > input:nth-child(35):checked ~ .tab-panels > .tab-panel:nth-child(18),
+.tabset > input:nth-child(37):checked ~ .tab-panels > .tab-panel:nth-child(19),
+.tabset > input:nth-child(39):checked ~ .tab-panels > .tab-panel:nth-child(20){
+    display: block;
 }
 
 .tabset > label {


### PR DESCRIPTION
**Type of PR:**
<!-- Add one of the following kinds: feature, bug, api-change, cleanup, deprecation, design, documentation, failing-test, flake, regression, support -->
/kind enhancement
<!--
Add one of the following kinds:
/kind enhancement
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it:**
<!-- Enter a description of the change and why this change is needed -->
This PR resolves documentation issues by fixing missing tab displays in mdbook configurations and correcting broken hyperlinks in the README.

**Which issue(s) this PR fixes:**
<!-- Optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged -->
Fixes #

**Release note:**
<!-- Write your release note. If no release note is required, just write "NONE". -->
```release-note

```
